### PR TITLE
Create user to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,13 @@ RUN cp /root/bamUtil/bin/bam /usr/bin/bam-non-primary-dedup
 RUN git --git-dir=/root/bamUtil/.git --work-tree=/root/bamUtil checkout b6e4a7de6b7ce08d488f539ada4f1717cd4d12e4 #ExternalMemorySortManager
 RUN make -C /root/bamUtil
 RUN cp /root/bamUtil/bin/bam /usr/bin/bam-ext-mem-sort-manager
+
+RUN groupadd datacommons; groupadd docker \
+    && useradd -m dockeruser -g docker -s /bin/bash \
+    && echo "dockeruser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/docker
+
+RUN chmod 777 -R /root
+RUN chmod 777 -R /usr
+RUN chown dockeruser:docker /tmp; chown dockeruser:docker /usr
+USER dockeruser
+WORKDIR /home/dockeruser


### PR DESCRIPTION
In reference to this comment: https://github.com/DataBiosphere/topmed-workflows/pull/66#issuecomment-409361449
In this PR: https://github.com/DataBiosphere/topmed-workflows/pull/66

I wanted to create a PR here to see if we can get the Dockerfile changes integrated into the `statgen/alignment` image. Running the CWL Workflow in Toil with a Docker container where the user is `root` causes problems. I modified the Dockerfile to create a user to run as when the Docker Image is launched. 

CWL Workflow: https://github.com/DataBiosphere/topmed-workflows/blob/master/aligner/sbg-alignment-cwl/topmed-alignment.cwl 
